### PR TITLE
Perbaiki dan sediakan kode postgresql supabase

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,15 @@
+# Supabase Configuration
+NEXT_PUBLIC_SUPABASE_URL=your_supabase_project_url
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
+SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
+
+# Application URL
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# Pakasir Configuration (Optional)
+PAKASIR_API_KEY=your_pakasir_api_key
+PAKASIR_SLUG=your_pakasir_slug
+
+# StarSender Configuration (Optional)
+STARSENDER_ACCOUNT_KEY=your_starsender_account_key
+STARSENDER_DEVICE_KEY=your_starsender_device_key

--- a/FIX_SETTINGS_INSTRUCTIONS.md
+++ b/FIX_SETTINGS_INSTRUCTIONS.md
@@ -1,0 +1,120 @@
+# Instruksi Perbaikan Settings
+
+## Langkah-langkah untuk memperbaiki masalah "Gagal menyimpan pengaturan":
+
+### 1. Jalankan SQL Script di Supabase
+
+Buka Supabase Dashboard, masuk ke SQL Editor, dan jalankan script berikut:
+
+```sql
+-- Fix Settings Table and Add Missing Columns
+-- =============================================
+
+-- Ensure settings table has all required columns
+ALTER TABLE public.settings 
+ADD COLUMN IF NOT EXISTS created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW();
+
+-- Add missing settings entries for the application
+INSERT INTO public.settings (key, value, description, type, updated_by) VALUES 
+-- System Settings
+('school_name', 'SD Indonesia', 'Nama sekolah', 'text', 'system'),
+('class_name', 'Kelas 1A', 'Nama kelas', 'text', 'system'),
+('teacher_name', 'Bu Sari', 'Nama wali kelas', 'text', 'system'),
+('phone_number', '628123456789', 'Nomor telepon wali kelas', 'text', 'system'),
+('email', 'teacher@school.com', 'Email wali kelas', 'text', 'system'),
+('default_payment_amount', '25000', 'Nominal pembayaran default', 'number', 'system'),
+('payment_due_day', '5', 'Tanggal jatuh tempo pembayaran (hari)', 'number', 'system'),
+('currency', 'IDR', 'Mata uang', 'text', 'system'),
+('timezone', 'Asia/Jakarta', 'Zona waktu', 'text', 'system'),
+
+-- Integration Settings
+('pakasir_api_key', '', 'API Key Pakasir', 'text', 'system'),
+('pakasir_slug', '', 'Slug Pakasir', 'text', 'system'),
+('pakasir_base_url', 'https://pakasir.zone.id', 'Base URL Pakasir', 'text', 'system'),
+('pakasir_redirect_url', 'https://berbagiakun.com', 'Redirect URL Pakasir', 'text', 'system'),
+('starsender_account_key', '', 'StarSender Account API Key', 'text', 'system'),
+('starsender_device_key', '', 'StarSender Device API Key', 'text', 'system'),
+
+-- Notification Settings
+('whatsapp_auto_reminders', 'false', 'Kirim reminder otomatis via WhatsApp', 'boolean', 'system'),
+('whatsapp_auto_confirmations', 'false', 'Kirim konfirmasi pembayaran otomatis', 'boolean', 'system'),
+('whatsapp_reminder_days_before', '3', 'Hari sebelum jatuh tempo untuk reminder', 'number', 'system'),
+('email_notifications', 'false', 'Kirim notifikasi via email', 'boolean', 'system'),
+('parent_portal_notifications', 'false', 'Tampilkan notifikasi di portal orang tua', 'boolean', 'system')
+ON CONFLICT (key) DO NOTHING;
+
+-- Create index for better performance
+CREATE INDEX IF NOT EXISTS idx_settings_key ON public.settings(key);
+
+-- Grant permissions
+GRANT ALL ON public.settings TO authenticated;
+GRANT ALL ON public.settings TO anon;
+```
+
+### 2. Verifikasi Tabel Settings
+
+Setelah menjalankan script di atas, jalankan query berikut untuk memverifikasi:
+
+```sql
+-- Check if all settings are created
+SELECT key, value, type FROM public.settings ORDER BY key;
+```
+
+### 3. Test Permissions
+
+Jalankan query ini untuk memastikan permissions sudah benar:
+
+```sql
+-- Check table permissions
+SELECT 
+    tablename,
+    tableowner,
+    has_table_privilege('anon', tablename, 'SELECT') as anon_select,
+    has_table_privilege('anon', tablename, 'INSERT') as anon_insert,
+    has_table_privilege('anon', tablename, 'UPDATE') as anon_update,
+    has_table_privilege('anon', tablename, 'DELETE') as anon_delete
+FROM pg_tables
+WHERE schemaname = 'public' AND tablename = 'settings';
+```
+
+### 4. Perubahan Code yang Sudah Dilakukan
+
+1. **Fixed `settings-service.ts`**:
+   - Method `getAllSettings()` sekarang mengembalikan object key-value pairs
+   - Method `bulkUpdateSettings()` sekarang bisa create setting baru jika belum ada
+   
+2. **Fixed `starsender-service.ts`**:
+   - Method `getApiKeys()` sekarang menggunakan `getSettingsAsObject()` yang benar
+
+### 5. Clear Browser Cache
+
+Setelah semua langkah di atas:
+1. Clear browser cache (Ctrl+Shift+Delete)
+2. Refresh halaman settings
+3. Coba simpan pengaturan lagi
+
+### 6. Troubleshooting
+
+Jika masih ada masalah, cek:
+
+1. **Browser Console** untuk error messages
+2. **Network Tab** untuk melihat response dari API
+3. **Supabase Dashboard** untuk melihat logs
+
+### 7. Manual Update Settings (Optional)
+
+Jika perlu update manual via SQL:
+
+```sql
+-- Update specific settings
+UPDATE public.settings SET value = 'your-api-key' WHERE key = 'pakasir_api_key';
+UPDATE public.settings SET value = 'your-slug' WHERE key = 'pakasir_slug';
+UPDATE public.settings SET value = 'your-account-key' WHERE key = 'starsender_account_key';
+UPDATE public.settings SET value = 'your-device-key' WHERE key = 'starsender_device_key';
+```
+
+## Catatan Penting
+
+- Pastikan Supabase URL dan Anon Key di `.env.local` sudah benar
+- Settings akan otomatis dibuat saat pertama kali save jika belum ada
+- Semua settings disimpan sebagai string di database, konversi dilakukan di aplikasi

--- a/database/sql-scripts/fix-settings-table.sql
+++ b/database/sql-scripts/fix-settings-table.sql
@@ -1,0 +1,42 @@
+-- Fix Settings Table and Add Missing Columns
+-- =============================================
+
+-- Ensure settings table has all required columns
+ALTER TABLE public.settings 
+ADD COLUMN IF NOT EXISTS created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW();
+
+-- Add missing settings entries for the application
+INSERT INTO public.settings (key, value, description, type, updated_by) VALUES 
+-- System Settings
+('school_name', 'SD Indonesia', 'Nama sekolah', 'text', 'system'),
+('class_name', 'Kelas 1A', 'Nama kelas', 'text', 'system'),
+('teacher_name', 'Bu Sari', 'Nama wali kelas', 'text', 'system'),
+('phone_number', '628123456789', 'Nomor telepon wali kelas', 'text', 'system'),
+('email', 'teacher@school.com', 'Email wali kelas', 'text', 'system'),
+('default_payment_amount', '25000', 'Nominal pembayaran default', 'number', 'system'),
+('payment_due_day', '5', 'Tanggal jatuh tempo pembayaran (hari)', 'number', 'system'),
+('currency', 'IDR', 'Mata uang', 'text', 'system'),
+('timezone', 'Asia/Jakarta', 'Zona waktu', 'text', 'system'),
+
+-- Integration Settings
+('pakasir_api_key', '', 'API Key Pakasir', 'text', 'system'),
+('pakasir_slug', '', 'Slug Pakasir', 'text', 'system'),
+('pakasir_base_url', 'https://pakasir.zone.id', 'Base URL Pakasir', 'text', 'system'),
+('pakasir_redirect_url', 'https://berbagiakun.com', 'Redirect URL Pakasir', 'text', 'system'),
+('starsender_account_key', '', 'StarSender Account API Key', 'text', 'system'),
+('starsender_device_key', '', 'StarSender Device API Key', 'text', 'system'),
+
+-- Notification Settings
+('whatsapp_auto_reminders', 'false', 'Kirim reminder otomatis via WhatsApp', 'boolean', 'system'),
+('whatsapp_auto_confirmations', 'false', 'Kirim konfirmasi pembayaran otomatis', 'boolean', 'system'),
+('whatsapp_reminder_days_before', '3', 'Hari sebelum jatuh tempo untuk reminder', 'number', 'system'),
+('email_notifications', 'false', 'Kirim notifikasi via email', 'boolean', 'system'),
+('parent_portal_notifications', 'false', 'Tampilkan notifikasi di portal orang tua', 'boolean', 'system')
+ON CONFLICT (key) DO NOTHING;
+
+-- Create index for better performance
+CREATE INDEX IF NOT EXISTS idx_settings_key ON public.settings(key);
+
+-- Grant permissions
+GRANT ALL ON public.settings TO authenticated;
+GRANT ALL ON public.settings TO anon;

--- a/lib/settings-service.ts
+++ b/lib/settings-service.ts
@@ -467,7 +467,10 @@ export class SettingsService {
 
     try {
       // Check existing settings
-      const { data: existingSettings } = await this.getAllSettings()
+      const { data: existingSettings } = await this.supabase
+        .from('settings')
+        .select('key')
+      
       const existingKeys = existingSettings?.map(s => s.key) || []
 
       // Insert only missing settings

--- a/lib/settings-service.ts
+++ b/lib/settings-service.ts
@@ -18,10 +18,22 @@ export class SettingsService {
   private supabase = supabase
 
   // Get all settings
-  async getAllSettings(): Promise<{ data: Settings[] | null; error: any }> {
+  async getAllSettings(): Promise<{ data: Record<string, string> | null; error: any }> {
     try {
-      const result = await supabaseHelpers.getSettings(this.supabase)
-      return result
+      const { data, error } = await this.supabase
+        .from('settings')
+        .select('*')
+        .order('key')
+      
+      if (error) throw error
+      
+      // Convert array to key-value object
+      const settingsObj = data?.reduce((acc: any, setting: any) => {
+        acc[setting.key] = setting.value
+        return acc
+      }, {} as Record<string, string>) || {}
+      
+      return { data: settingsObj, error: null }
     } catch (error) {
       console.error('Error fetching settings:', error)
       return { data: null, error }
@@ -103,19 +115,52 @@ export class SettingsService {
   // Bulk update settings
   async bulkUpdateSettings(updates: Array<{ key: string; value: string }>, updatedBy?: string): Promise<{ data: Settings[] | null; error: any }> {
     try {
-      const promises = updates.map(update => 
-        this.updateSetting(update.key, update.value, updatedBy)
-      )
+      const results: Settings[] = []
       
-      const results = await Promise.all(promises)
-      const errors = results.filter(r => r.error)
-      
-      if (errors.length > 0) {
-        return { data: null, error: errors[0].error }
+      for (const update of updates) {
+        // Check if setting exists
+        const { data: existing } = await this.supabase
+          .from('settings')
+          .select('id')
+          .eq('key', update.key)
+          .single()
+        
+        if (existing) {
+          // Update existing setting
+          const { data, error } = await this.supabase
+            .from('settings')
+            .update({
+              value: update.value,
+              updated_by: updatedBy,
+              updated_at: new Date().toISOString()
+            })
+            .eq('key', update.key)
+            .select()
+            .single()
+          
+          if (error) throw error
+          if (data) results.push(data)
+        } else {
+          // Create new setting
+          const { data, error } = await this.supabase
+            .from('settings')
+            .insert({
+              key: update.key,
+              value: update.value,
+              type: 'text',
+              updated_by: updatedBy,
+              created_at: new Date().toISOString(),
+              updated_at: new Date().toISOString()
+            })
+            .select()
+            .single()
+          
+          if (error) throw error
+          if (data) results.push(data)
+        }
       }
       
-      const data = results.map(r => r.data).filter(Boolean) as Settings[]
-      return { data, error: null }
+      return { data: results, error: null }
     } catch (error) {
       console.error('Error bulk updating settings:', error)
       return { data: null, error }

--- a/lib/starsender-service.ts
+++ b/lib/starsender-service.ts
@@ -40,10 +40,14 @@ class StarSenderService {
   
   // Get API keys from settings
   async getApiKeys(): Promise<{ accountKey: string; deviceKey: string }> {
-    const settings = await settingsService.getWhatsAppSettings()
+    const { data: settings } = await settingsService.getSettingsAsObject([
+      'starsender_account_key',
+      'starsender_device_key'
+    ])
+    
     return {
-      accountKey: settings.apiKey || '', // Account API key for campaigns
-      deviceKey: settings.deviceApiKey || '' // Device API key for sending messages
+      accountKey: settings?.starsender_account_key || '', // Account API key for campaigns
+      deviceKey: settings?.starsender_device_key || '' // Device API key for sending messages
     }
   }
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes "Gagal menyimpan pengaturan" (Failed to save settings) by initializing database settings and improving backend settings management.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The "Gagal menyimpan pengaturan" error was caused by missing default entries in the `settings` table and the application's `settings-service` not creating new settings if they didn't exist during an update. Additionally, `getAllSettings` was returning an array, which was incompatible with services expecting a key-value object. This PR adds a SQL script to ensure the database is correctly initialized and updates the application logic to handle setting creation and retrieval robustly.

---
<a href="https://cursor.com/background-agent?bcId=bc-397de326-89e7-4574-8022-19a37b93a18e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-397de326-89e7-4574-8022-19a37b93a18e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>